### PR TITLE
Fix bug with stream not completing when only one page of results

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -37,7 +37,7 @@ MarketoStream.prototype._read = function() {
   if (this._data.result) {
     if (this._pushNext()) {
       return;
-    } else if (_.has(this._data, 'nextPage')) {
+    } else if (this._data.moreResult) {
       this._setData(this._data.nextPage())
     } else {
       // No data left and no more data from marketo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-marketo",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "marketo rest client",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix for #26. The moreResult parameter seems to be the documented way to know if the stream has more data to pull or not.