### PR TITLE
Add event emitter to log apiCalls

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,8 +3,9 @@ var _ = require('lodash'),
     Promise = require('bluebird'),
     Retry = require('./retry'),
     errors = require('./errors'),
-    util = require('./util'),
-    log = util.logger(),
+    util = require('util'),
+    EventEmitter = require('events').EventEmitter,
+    log = require('./util').logger(),
     restlerMethodArgCount = {
       get: 2,
       post: 2,
@@ -21,9 +22,11 @@ var _ = require('lodash'),
 var OAUTH_TOKEN_PATH = '/oauth/token';
 
 function Connection(options) {
+  EventEmitter.call(this);
   this._options = options || {};
   this._tokenData = null;
   this._retry = new Retry(options.retry || {});
+  this.apiCallCount = 0;
 
   // Convenient methods, matches that of restler's
   _.each(restlerMethodArgCount, function(count, method) {
@@ -38,6 +41,8 @@ function Connection(options) {
     };
   }, this);
 }
+
+util.inherits(Connection, EventEmitter);
 
 function getNextPageFn(conn, method, args) {
   var options = _.clone(_.last(args) || {});
@@ -57,126 +62,126 @@ function getNextPageFn(conn, method, args) {
   }
 }
 
-Connection.prototype = {
-  /**
-   * This function is just a helper function that delegates everything to
-   * restler, but returns a Promise instead of going with the existing event
-   * based resposnes.
-   */
-  _request: function(method) {
-    var args = Array.prototype.slice.call(arguments, 1),
-        url = _.first(args);
+/**
+ * This function is just a helper function that delegates everything to
+ * restler, but returns a Promise instead of going with the existing event
+ * based resposnes.
+ */
+Connection.prototype._request = function(method) {
+  var args = Array.prototype.slice.call(arguments, 1),
+      url = _.first(args);
 
-    // If the url does not start with http(s)://, then assume that it's an
-    // absolute path from options.endpoint
-    if (!/^https?:\/\//i.test(url)) {
-      args[0] = this._options.endpoint + url;
-    }
+  // If the url does not start with http(s)://, then assume that it's an
+  // absolute path from options.endpoint
+  if (!/^https?:\/\//i.test(url)) {
+    args[0] = this._options.endpoint + url;
+  }
 
-    log.debug('Request:', arguments);
+  this.apiCallCount += 1;
+  this.emit('apiCall', { apiCallCount: this.apiCallCount });
+  log.debug('Request:', arguments);
 
-    var requestFn = function requestFn(forceOAuth) {
-      return this.getOAuthToken(forceOAuth)
-        .then(function(token) {
-          var defer = Promise.defer(),
-              options = _.last(args) || {},
-              nextPageFn = getNextPageFn(this, method, args);
+  var requestFn = function requestFn(forceOAuth) {
+    return this.getOAuthToken(forceOAuth)
+      .then(function(token) {
+        var defer = Promise.defer(),
+            options = _.last(args) || {},
+            nextPageFn = getNextPageFn(this, method, args);
 
-          args.pop();
-          options.headers = _.extend({}, options.headers, {
-            'Authorization': 'Bearer ' + token.access_token
-          });
-          args.push(options);
-
-          rest[method].apply(rest, args)
-            .on('success', function(data, resp) {
-              if (data.success === false && _.has(data, 'errors')) {
-                log.debug('Request failed: ', data);
-                defer.reject(data);
-              } else {
-                if (_.has(data, 'nextPageToken')) {
-                  Object.defineProperty(data, 'nextPage', {
-                    enumerable: false,
-                    value: _.partial(nextPageFn, data.nextPageToken)
-                  });
-                }
-                defer.resolve(data);
-              }
-            })
-            .on('error', function(err, resp) {
-              defer.reject(err);
-            })
-            .on('fail', function(data, resp) {
-              // We cannot hook into the 4XX and 5XX events because the fail event
-              // appears to fire first. Both 4XX and 5XX errors trigger the 'fail'
-              // event.
-              var statusCode = Math.floor(resp.statusCode / 100);
-
-              if (statusCode === 5) {
-                defer.reject(new errors.Http5XXError(data));
-              } else if (statusCode === 4) {
-                defer.reject(new errors.Http4XXError(data));
-              } else {
-                defer.reject(data);
-              }
-            })
-            .on('timeout', function(ms) {
-              defer.reject(new errors.TimeoutError(ms));
-            });
-
-            return defer.promise;
-        }.bind(this), function(e) {
-          log.info('Unable to authenticate: ', e[0]);
+        args.pop();
+        options.headers = _.extend({}, options.headers, {
+          'Authorization': 'Bearer ' + token.access_token
         });
-    };
+        args.push(options);
 
-    return this._retry.start(requestFn, this);
-  },
-
-  getOAuthToken: function(force) {
-    var requestFn, defer;
-    force = force || false;
-
-    if (force || this._tokenData == null) {
-      defer = Promise.defer();
-
-      requestFn = function() {
-        var getOptions = {
-          query: this._getTokenQuery(),
-          timeout: this._options.timeout || 20000
-        };
-        rest.get(this._options.identity + OAUTH_TOKEN_PATH, getOptions)
+        rest[method].apply(rest, args)
           .on('success', function(data, resp) {
-            log.debug('Got token: ', data);
-            this._tokenData = data;
-            defer.resolve(data);
-          }.bind(this))
-          .on('timeout', function(ms) {
-            log.debug('Timeout');
-            defer.reject(ms);
+            if (data.success === false && _.has(data, 'errors')) {
+              log.debug('Request failed: ', data);
+              defer.reject(data);
+            } else {
+              if (_.has(data, 'nextPageToken')) {
+                Object.defineProperty(data, 'nextPage', {
+                  enumerable: false,
+                  value: _.partial(nextPageFn, data.nextPageToken)
+                });
+              }
+              defer.resolve(data);
+            }
+          })
+          .on('error', function(err, resp) {
+            defer.reject(err);
           })
           .on('fail', function(data, resp) {
-            defer.reject(data);
-          })
-          .on('error', function(err){
-            defer.reject(err);
-          });
-        return defer.promise;
-      };
-      return this._retry.start(requestFn, this);
-    } else {
-      log.debug('Using existing token: ', this._tokenData);
-      return Promise.resolve(this._tokenData);
-    }
-  },
+            // We cannot hook into the 4XX and 5XX events because the fail event
+            // appears to fire first. Both 4XX and 5XX errors trigger the 'fail'
+            // event.
+            var statusCode = Math.floor(resp.statusCode / 100);
 
-  _getTokenQuery: function() {
-    return {
-      grant_type: 'client_credentials',
-      client_id: this._options.clientId,
-      client_secret: this._options.clientSecret
+            if (statusCode === 5) {
+              defer.reject(new errors.Http5XXError(data));
+            } else if (statusCode === 4) {
+              defer.reject(new errors.Http4XXError(data));
+            } else {
+              defer.reject(data);
+            }
+          })
+          .on('timeout', function(ms) {
+            defer.reject(new errors.TimeoutError(ms));
+          });
+
+          return defer.promise;
+      }.bind(this), function(e) {
+        log.info('Unable to authenticate: ', e[0]);
+      });
+  };
+
+  return this._retry.start(requestFn, this);
+};
+
+Connection.prototype.getOAuthToken = function(force) {
+  var requestFn, defer;
+  force = force || false;
+
+  if (force || this._tokenData == null) {
+    defer = Promise.defer();
+
+    requestFn = function() {
+      var getOptions = {
+        query: this._getTokenQuery(),
+        timeout: this._options.timeout || 20000
+      };
+      rest.get(this._options.identity + OAUTH_TOKEN_PATH, getOptions)
+        .on('success', function(data, resp) {
+          log.debug('Got token: ', data);
+          this._tokenData = data;
+          defer.resolve(data);
+        }.bind(this))
+        .on('timeout', function(ms) {
+          log.debug('Timeout');
+          defer.reject(ms);
+        })
+        .on('fail', function(data, resp) {
+          defer.reject(data);
+        })
+        .on('error', function(err){
+          defer.reject(err);
+        });
+      return defer.promise;
     };
+    return this._retry.start(requestFn, this);
+  } else {
+    log.debug('Using existing token: ', this._tokenData);
+    return Promise.resolve(this._tokenData);
   }
+};
+
+Connection.prototype._getTokenQuery = function() {
+  return {
+    grant_type: 'client_credentials',
+    client_id: this._options.clientId,
+    client_secret: this._options.clientSecret
+  };
 };
 
 module.exports = Connection;

--- a/lib/marketo.js
+++ b/lib/marketo.js
@@ -1,4 +1,6 @@
 var _ = require('lodash'),
+    util = require('util'),
+    EventEmitter = require('events').EventEmitter,
     Activities = require('./api/activities'),
     Connection = require('./connection'),
     Campaign = require('./api/campaign'),
@@ -10,7 +12,13 @@ var _ = require('lodash'),
     MarketoStream = require('./stream');
 
 function Marketo(options) {
+  EventEmitter.call(this);
+
   this._connection = new Connection(options);
+
+  this._connection.on('apiCall', data => {
+    this.emit('apiCall', data);
+  });
 
   this.campaign = new Campaign(this, this._connection);
   this.email = new Email(this, this._connection);
@@ -21,10 +29,10 @@ function Marketo(options) {
   this.activities = new Activities(this, this._connection);
 }
 
-Marketo.prototype = {
-  getOAuthToken: function oauthToken() {
-    return this._connection.getOAuthToken(true);
-  }
+util.inherits(Marketo, EventEmitter);
+
+Marketo.prototype.getOAuthToken = function oauthToken() {
+  return this._connection.getOAuthToken(true);
 };
 
 Marketo.streamify = function streamify(marketoResult) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-marketo-rest",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "marketo rest client",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Experimental feature to allow for better surveillance of the total number of API calls made.

The connection keeps track of the number of Marketo API call it makes. Each one gets emitted as an 'apiCall' event by the client.

Usable via
```
marketo.on('apiCall', data => {
    console.log(data);
});
```