### PR TITLE
fix streaming pagination

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -42,7 +42,7 @@ MarketoStream.prototype._read = function() {
   if (this._data.result) {
     if (this._pushNext()) {
       return;
-    } else if (this._data.moreResult) {
+    } else if (this._data.nextPage) {
       this._setData(this._data.nextPage())
     } else {
       // No data left and no more data from marketo

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -42,7 +42,7 @@ MarketoStream.prototype._read = function() {
   if (this._data.result) {
     if (this._pushNext()) {
       return;
-    } else if (this._data.nextPage) {
+    } else if (this._data.moreResult || this._data.nextPageToken) {
       this._setData(this._data.nextPage())
     } else {
       // No data left and no more data from marketo


### PR DESCRIPTION
The `moreResult` key does not appear in any other part of the codebase, so I'll assume it is a relic from early releases. My initial experience was my stream would emit `end` after 300 objects, but with this change it ended after 3249 objects.