### PR TITLE
add optional partnerId param support for connection's getTokenQuery m…

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -166,11 +166,16 @@ Connection.prototype.getOAuthToken = function(force) {
 };
 
 Connection.prototype._getTokenQuery = function() {
-  return {
+  var queryOptions = {
     grant_type: 'client_credentials',
     client_id: this._options.clientId,
     client_secret: this._options.clientSecret
   };
+  var partnerId = this._options.partnerId;
+  if (partnerId) {
+    queryOptions.partner_id = partnerId;
+  }
+  return queryOptions;
 };
 
 module.exports = Connection;


### PR DESCRIPTION
…ethod

Marketo has an optional partner_id param that you can pass when requesting an oath token
see http://developers.marketo.com/support/Marketo_LaunchPoint_Technology_Partner_API_Key.pdf