### PR TITLE
Support 'mergeInCRM' parameter when merging Leads

### DIFF
--- a/lib/api/lead.js
+++ b/lib/api/lead.js
@@ -106,7 +106,12 @@ Lead.prototype = {
     }
 
     var path = util.createPath('leads', winningLead, 'merge.json');
-    return this._connection.postJson(path, {data: options}, {query: {leadIds: losingLeads.join()}});
+    var queryParams = {leadIds: losingLeads.join()}
+    if ('mergeInCRM' in options) {
+      queryParams.mergeInCRM = options.mergeInCRM
+      delete options.mergeInCRM
+    }
+    return this._connection.postJson(path, {data: options}, {query: queryParams});
   },
 
   getPageToken: function(sinceDatetime, options) {


### PR DESCRIPTION
The `mergeInCRM` parameter is actually a query parameter.   There was previously no way to pass this along.

http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/mergeLeadsUsingPOST