### PR TITLE
Leads: Add support for describe2 endpoint

### DIFF
--- a/lib/api/lead.js
+++ b/lib/api/lead.js
@@ -93,6 +93,11 @@ Lead.prototype = {
     return this._connection.get(path);
   },
 
+  describe2: function() {
+    var path = util.createPath('leads', 'describe2.json');
+    return this._connection.get(path);
+  },
+
   partitions: function() {
     var path = util.createPath('leads', 'partitions.json');
     return this._connection.get(path);


### PR DESCRIPTION
This PR adds support for the describe2.json leads API endpoint, addressing issue: https://github.com/MadKudu/node-marketo/issues/75