### PR TITLE
Use partial retrieval in order to get a bulk file

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,33 @@ marketo.bulkLeadExtract.get(
   });
 ```
 
+You can get the bulk `bulkLeadExtract.file` but this is not recommended as it will load all the file in-memory.
+
+The recommended way to get the file is by using `bulkLeadExtract.fileStream`. This will retrieve the file using a stream of chunked content (by default 750 KB).
+
+The `bulkLeadExtract.fileStream` accepts three parameters:
+
+1. exportId: The same parameter passed to `bulkLeadExtract.file`;
+2. fileSize: required in order to know when to stop the stream;
+3. rangeSize: optional if you want to override the default 750 KB range size (in bytes).
+
+Here is an example:
+
+```js
+const {
+  result: [{ exportId, fileSize }],
+} = await client.bulkLeadExtract.get(
+  ['firstName', 'lastName', 'id', 'email'],
+  { staticListName: 'some list name' }
+);
+
+const fileStream = await client.bulkLeadExtract.fileStream(
+  exportId,
+  fileSize,
+  1000000
+);
+```
+
 ####Bulk Activity Extract
 Follow the same convention as bulk extracting leads, but provide different filter information for the start/end date, activity type ids and any other supported filters or parameters. [Marketo Docs] (http://developers.marketo.com/rest-api/bulk-extract/bulk-activity-extract/)
 

--- a/lib/BulkFileStream.js
+++ b/lib/BulkFileStream.js
@@ -1,0 +1,42 @@
+const { Readable } = require('stream');
+
+const DEFAULT_RANGE_SIZE = 750000; // 750 KB
+
+class BulkFileStream extends Readable {
+  constructor(_connection, path, fileSize, rangeSize) {
+    super();
+    this._connection = _connection;
+    this.path = path;
+    this.start = 0;
+    this.fileSize = fileSize;
+    this.rangeSize = rangeSize || DEFAULT_RANGE_SIZE;
+  }
+
+  async _read() {
+    if (this.start !== null) {
+      let end = this.start + this.rangeSize;
+      if (end >= this.fileSize) {
+        end = this.fileSize - 1;
+      }
+
+      const data = await this._connection.get(this.path, {
+        data: { _method: 'GET' },
+        headers: {
+          Range: `bytes=${this.start}-${end}`,
+        },
+      });
+
+      if (end === this.fileSize - 1) {
+        this.start = null;
+      } else {
+        this.start = end + 1;
+      }
+
+      this.push(data);
+    } else {
+      this.push(null);
+    }
+  }
+}
+
+module.exports = BulkFileStream;

--- a/lib/api/bulkActivityExtract.js
+++ b/lib/api/bulkActivityExtract.js
@@ -2,6 +2,7 @@ var _ = require('lodash'),
   Promise = require('bluebird'),
   util = require('../util'),
   Retry = require('../retry'),
+  BulkFileStream = require('../BulkFileStream'),
   log = util.logger();
 
 function BulkActivityExtract(marketo, connection) {
@@ -96,12 +97,10 @@ BulkActivityExtract.prototype = {
     });
     return this._connection.get(path, { data: options });
   },
-  fileStream: async function (exportId) {
-    const endpoint = this._connection.getEndpoint();
-    const token = await this._connection.getOAuthToken();
-    const fileStream = await util.getFileStream(endpoint, 'activities', exportId, token);
-
-    return fileStream;
+  fileStream: async function (exportId, fileSize, rangeSize) {
+    var path = util.createBulkPath('activities', 'export', exportId, 'file.json');
+    
+    return new BulkFileStream(this._connection, path, fileSize, rangeSize);
   },
 };
 

--- a/lib/api/bulkLeadExtract.js
+++ b/lib/api/bulkLeadExtract.js
@@ -2,6 +2,7 @@ var _ = require('lodash'),
   Promise = require('bluebird'),
   util = require('../util'),
   Retry = require('../retry'),
+  BulkFileStream = require('../BulkFileStream'),
   log = util.logger();
 
 function BulkLeadExtract(marketo, connection) {
@@ -103,12 +104,10 @@ BulkLeadExtract.prototype = {
     });
     return this._connection.get(path, { data: options });
   },
-  fileStream: async function (exportId) {
-    const endpoint = this._connection.getEndpoint();
-    const token = await this._connection.getOAuthToken();
-    const fileStream = await util.getFileStream(endpoint, 'leads', exportId, token);
-
-    return fileStream;
+  fileStream: async function (exportId, fileSize, rangeSize) {
+    var path = util.createBulkPath('leads', 'export', exportId, 'file.json');
+    
+    return new BulkFileStream(this._connection, path, fileSize, rangeSize);
   },
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -76,30 +76,5 @@ module.exports = {
         type = 'offset';
     }
     return type;
-  },
-
-  getFileStream: function(endpoint, object, exportId, token) {
-    return new Promise(async (resolve) => {
-      const pathToFile = createBulkPath(
-        object,
-        'export',
-        exportId,
-        'file.json'
-      );
-      const trimmedPathToFile = pathToFile.replace('/..', '');
-      const path = endpoint.replace('/rest', trimmedPathToFile);
-    
-      return https.get(
-        path,
-        {
-          headers: {
-            Authorization: `Bearer ${token.access_token}`,
-          },
-        },
-        (response) => {
-          resolve(response);
-        }
-      );
-    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-marketo-rest",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "marketo rest client",
   "repository": {
     "type": "git",

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -17,27 +17,4 @@ describe('util', () => {
       expect(path).to.equal('/../bulk/v1/activities/export/create.json');
     });
   });
-
-  describe('getFileStream', () => {
-    it('should get file stream correctly', async () => {
-      const endpoint = 'https://www.marketo.com';
-      const token = 'token';
-      const dataMock = 'file stream';
-
-      nock(endpoint)
-        .get('/')
-        .reply(200, dataMock);
-      
-      const fileStream = await getFileStream(endpoint, 'activities', '123-567-', token);
-      
-      let data = '';
-      fileStream
-        .on('data', (chunk) => {
-          data += chunk;
-        })
-        .on('end', () => {
-          expect(data).to.equal(dataMock);
-        });
-    });
-  });
 });


### PR DESCRIPTION
## Motive

Using the HTTP stream was not sufficient as we had an `ECONNRESET` error.
The HTTP connection was lost before we finished parsing the file.

## Solution

Use [partial retrieval](https://developers.marketo.com/rest-api/bulk-extract/#partial_retrieval_and_resumption). This allows to get the file in small chunks and have less memory footprint as we can pause/resume the stream. 

## Tests

I tested the new fileStream function with the `rangeSize` parameter and without.

The stream succeeds in getting the file parts sequentially.

